### PR TITLE
Fixed the link to kaitaiStructCompile.py again :(

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A curated list of Kaitai Struct tools and resources
   - [webide-usercontent.kaitai.io](https://github.com/kaitai-io/webide-usercontent.kaitai.io) - Used in sandboxing for the WebIDE
 - [Development version of the IDE](https://ide.kaitai.io/devel/) ([Github Page](https://github.com/kaitai-io/ide-devel-kaitai-io.github.io))
 - Kaitai Struct: visualizer and hex viewer tool ([Repository](https://github.com/kaitai-io/kaitai_struct_visualizer))
-- kaitaiStructCompile.py - Automate ksy compilation into python files ([Repository](https://gitlab.com/KOLANICH/kaitaiStructCompile.py))
+- kaitaiStructCompile.py - Automate ksy compilation into python files ([Repository](https://gitlab.com/kaitaiStructCompile.py/kaitaiStructCompile.py))
 - Kaitai Struct: visualizer and hex viewer tool GUI in Java ([Repository](https://github.com/kaitai-io/kaitai_struct_gui), [Issues](https://github.com/kaitai-io/kaitai_struct_gui/issues)) - *deprecated?*
 
 ## Converter


### PR DESCRIPTION
I'm sorry, have forgotten that I have moved it.